### PR TITLE
Small typing fixes

### DIFF
--- a/packages/builder/src/bounds.js
+++ b/packages/builder/src/bounds.js
@@ -48,7 +48,7 @@ export class Bounds {
 
   intersection(other) {
     if (this.isNull || other.isNull) {
-      return this.constructor.null;
+      return Bounds.null;
     }
 
     const minX = Math.max(this.minX, other.minX);
@@ -57,19 +57,19 @@ export class Bounds {
     const maxY = Math.min(this.maxY, other.maxY);
 
     if (minX > maxX || minY > maxY) {
-      return this.constructor.null;
+      return Bounds.null;
     }
 
-    return new this.constructor(minX, minY, maxX, maxY);
+    return new Bounds(minX, minY, maxX, maxY);
   }
 
   union(other) {
     if (this.isNull) {
-      return new this.constructor(other.minX, other.minY, other.maxX, other.maxY);
+      return new Bounds(other.minX, other.minY, other.maxX, other.maxY);
     }
 
     if (other.isNull) {
-      return new this.constructor(this.minX, this.minY, this.maxX, this.maxY);
+      return new Bounds(this.minX, this.minY, this.maxX, this.maxY);
     }
 
     const minX = Math.min(this.minX, other.minX);
@@ -77,22 +77,22 @@ export class Bounds {
     const maxX = Math.max(this.maxX, other.maxX);
     const maxY = Math.max(this.maxY, other.maxY);
 
-    return new this.constructor(minX, minY, maxX, maxY);
+    return new Bounds(minX, minY, maxX, maxY);
   }
 
   insetBy(dMinX, dMinY = dMinX, dMaxX = dMinX, dMaxY = dMinY) {
     if (dMinX + dMaxX > this.width || dMinY + dMaxY > this.height) {
-      return this.constructor.null;
+      return Bounds.null;
     }
 
-    return new this.constructor(this.minX + dMinX, this.minY + dMinY, this.maxX - dMaxX, this.maxY - dMaxY);
+    return new Bounds(this.minX + dMinX, this.minY + dMinY, this.maxX - dMaxX, this.maxY - dMaxY);
   }
 
   offsetBy(dx, dy) {
-    return new this.constructor(this.minX + dx, this.minY + dy, this.maxX + dx, this.maxY + dy);
+    return new Bounds(this.minX + dx, this.minY + dy, this.maxX + dx, this.maxY + dy);
   }
 
   centeredAt(cx, cy) {
-    return new this.constructor(cx - this.width * 0.5, cy - this.height * 0.5, cx + this.width * 0.5, cy + this.height * 0.5);
+    return new Bounds(cx - this.width * 0.5, cy - this.height * 0.5, cx + this.width * 0.5, cy + this.height * 0.5);
   }
 }

--- a/packages/builder/src/clip.js
+++ b/packages/builder/src/clip.js
@@ -124,7 +124,7 @@ function clipLine(geom, newGeom, k1, k2, axis, isPolygon) {
 
 function clipLines(geom, newGeom, k1, k2, axis, isPolygon) {
     for (const line of geom) {
-        clipLine(line, newGeom, k1, k2, axis, isPolygon, false);
+        clipLine(line, newGeom, k1, k2, axis, isPolygon);
     }
 }
 

--- a/packages/builder/src/simple-transform.js
+++ b/packages/builder/src/simple-transform.js
@@ -13,11 +13,10 @@ export class SimpleTransform {
     const ty = this.ty;
 
     if (a == 0) {
-      console.warn("Can't invert transform with zero scale");
-      return new this.constructor(a, tx, ty);
+      throw new Error("Can't invert transform with zero scale");
     }
 
-    return new this.constructor(
+    return new SimpleTransform(
       1 / a,
       1 / a * -tx,
       1 / a * -ty
@@ -25,7 +24,7 @@ export class SimpleTransform {
   }
 
   concat(t) {
-    return new this.constructor(
+    return new SimpleTransform(
       this.a * t.a,
       this.a * t.tx + this.tx,
       this.a * t.ty + this.ty
@@ -33,7 +32,7 @@ export class SimpleTransform {
   }
 
   scale(s) {
-    return new this.constructor(
+    return new SimpleTransform(
       this.a * s,
       this.tx,
       this.ty
@@ -41,7 +40,7 @@ export class SimpleTransform {
   }
 
   translate(dx, dy) {
-    return new this.constructor(
+    return new SimpleTransform(
       this.a,
       this.a * dx + this.tx,
       this.a * dy + this.ty


### PR DESCRIPTION
- Remove an extra argument
- Switch to explicit class names in `Bounds` and `SimpleTransform`